### PR TITLE
feat(build): add publishing workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+# Description
+<!-- Provide an accurate description of the changes this Pull Request introduces. -->
+
+# Proposed Changes
+<!-- Outline the technical changes of the code in this Pull Request. -->
+
+# References
+<!-- Provide any resources that are beneficial to reviewers of this Pull Request. -->
+
+# Contribution Standards
+<!-- Confirm that your contributions are following the best practices and standards adopted by this repository. -->
+- [ ] Unit tests have been added for any additional functionality introduced, or no additional unit tests are required.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 
 # References
 <!-- Provide any resources that are beneficial to reviewers of this Pull Request. -->
+- N/A
 
 # Contribution Standards
 <!-- Confirm that your contributions are following the best practices and standards adopted by this repository. -->

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
     - run: npm version
     - run: npm publish --access public
       env:
-        NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+        NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
     - run: |
         git config --global user.name "ERC-721 NES"
         git config --global user.email "no-reply@dev.null"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: ERC-721 NES - Deploy Version (Patch)
+
+on:
+  push:
+    tags:
+      - deploy-patch
+
+jobs:
+  # Need to pull out "tests" into the Github Actions equivalent of CircleCI "orbs"
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npx hardhat test
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 16
+        registry-url: https://registry.npmjs.org/
+    - run: npm ci
+    - run: cp contracts/ERC721NES.sol ./ERC721NES.sol
+    - run: npm version
+    - run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+    - run: |
+        git config --global user.name "ERC-721 NES"
+        git config --global user.email "no-reply@dev.null"
+
+        git add package.json
+        git commit -m "release: update package.json"
+        git push

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,4 @@ jobs:
     - run: |
         git config --global user.name "ERC-721 NES"
         git config --global user.email "no-reply@dev.null"
-
-        git add package.json
-        git commit -m "release: update package.json"
         git push

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.github
+contracts
+test
+.gitignore
+hardhat.config.js
+package-lock.json


### PR DESCRIPTION
# Description
Implements a deployment pipeline so that Github Actions can publish new versions of the `erc721nes` NPM package.

# Proposed Changes
1. Creates a new Github Workflow: `.github/workflows/deploy-patch.yml`
   1. Checks out latest sha from master
   2. Runs test suite
   3. Creates distributable package
   4. Runs `npm version patch`
   5. Runs `npm publish --access public`
   6. Commits updated `package.json` back to repo
 2. Run this new Github Workflow whenever the tag `deploy-patch` is pushed

# References

# Contribution Standards
- [x] Unit tests have been added for any additional functionality introduced, or no additional unit tests are required.