### PR TITLE
fix(build): run npm version patch instead of just version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
         registry-url: https://registry.npmjs.org/
     - run: npm ci
     - run: cp contracts/ERC721NES.sol ./ERC721NES.sol
-    - run: npm version
+    - run: npm version patch
     - run: npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
# Description
Need to run `npm version patch` to generate new commit upticking version.

# Proposed Changes
- Run `npm version patch` instead of `npm version`

# References
- N/A

# Contribution Standards
<!-- Confirm that your contributions are following the best practices and standards adopted by this repository. -->
- [x] Unit tests have been added for any additional functionality introduced, or no additional unit tests are required.